### PR TITLE
Update Docker File from 3.1 to 3.5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ RUN apt-get -q update \
 
 # Install mattermost
 RUN cd /root/ \
- && wget https://releases.mattermost.com/3.1.0/mattermost-team-3.1.0-linux-amd64.tar.gz -O mattermost.tar.gz \
+ && wget https://releases.mattermost.com/3.5.1/mattermost-3.5.1-linux-amd64.tar.gz -O mattermost.tar.gz \
  && tar -xvzf mattermost.tar.gz \
  && rm -fr mattermost.tar.gz \
  && mkdir -p /mattermost/data


### PR DESCRIPTION
Updated line 31 to 
 && wget https://releases.mattermost.com/3.1.0/mattermost-team-3.1.0-linux-amd64.tar.gz -O mattermost.tar.gz \
to
 && wget https://releases.mattermost.com/3.5.1/mattermost-3.5.1-linux-amd64.tar.gz -O mattermost.tar.gz \

Not sure if this is the right way to do this but time to learn.