### PR TITLE
supervisor: fix working directory

### DIFF
--- a/4.9.1/overlay/etc/supervisor/conf.d/mattermost.conf
+++ b/4.9.1/overlay/etc/supervisor/conf.d/mattermost.conf
@@ -1,5 +1,5 @@
 [program:mattermost-platform]
-directory=/root/mattermost/bin
+directory=/root/mattermost
 command=/root/mattermost/bin/platform
 autostart=true
 autorestart=true


### PR DESCRIPTION
The working directory is expected to be the root directory for the Mattermost installation.

Otherwise this breaks things like plugins (which are expected to be in a `./plugins` subdirectory).